### PR TITLE
test: Validate manager retrieval

### DIFF
--- a/test/taskmanagement/manager/ManagersTest.java
+++ b/test/taskmanagement/manager/ManagersTest.java
@@ -1,0 +1,17 @@
+package taskmanagement.manager;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ManagersTest {
+
+    @Test
+    void testGetDefault() {
+        TaskManager taskManager = Managers.getDefault();
+        HistoryManager historyManager = Managers.getDefaultHistory();
+
+        assertNotNull(taskManager, "Должен быть возвращен проинициализированный экземпляр TaskManager");
+        assertNotNull(historyManager, "Должен быть возвращен проинициализированный экземпляр HistoryManager");
+    }
+}


### PR DESCRIPTION
#comment Ensure the default instances of TaskManager and HistoryManager are not null when retrieved

Affected: ManagersTest