### PR TITLE
test: Prevent epic task as subtask

### DIFF
--- a/test/taskmanagement/task/EpicTaskTest.java
+++ b/test/taskmanagement/task/EpicTaskTest.java
@@ -1,0 +1,18 @@
+package taskmanagement.task;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EpicTaskTest {
+
+    @Test
+    void testCannotAddEpicAsSubtask() {
+        EpicTask epic = new EpicTask("Epic", "Description");
+        epic.setId(1);
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            epic.addSubtask(epic.getId());
+        }, "Эпик не может быть добавлен в виде подзадачи к самому себе");
+        assertEquals("Эпик не может быть добавлен в виде подзадачи к самому себе", exception.getMessage());
+    }
+}


### PR DESCRIPTION
#comment Ensure that an EpicTask cannot be added as a subtask to itself to maintain task hierarchy integrity

Affected: EpicTaskTest