### PR TITLE
test: Prevent self-referencing subtask

### DIFF
--- a/test/taskmanagement/task/SubtaskTest.java
+++ b/test/taskmanagement/task/SubtaskTest.java
@@ -1,0 +1,21 @@
+package taskmanagement.task;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SubtaskTest {
+
+    @Test
+    void testCannotSetSelfAsEpic() {
+        EpicTask epic = new EpicTask("Epic", "Description");
+        epic.setId(1);
+        Subtask subtask = new Subtask("Subtask", "Description", epic.getId());
+        subtask.setId(1);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            new Subtask("Subtask", "Description", subtask.getId());
+        }, "Подзадача не может быть своим же эпиком");
+        assertEquals("Подзадача не может быть своим же эпиком", exception.getMessage());
+    }
+}


### PR DESCRIPTION
#comment Ensure that a Subtask cannot reference itself as its own epic to maintain task hierarchy integrity

Affected: SubtaskTest